### PR TITLE
Add more commands, add context variable for keybind "when" clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is an extension for Visual Studio Code which provides region selection simi
 
 ## Compatibility With Other Extensions
 
-It is possible to combine this extension with other selection extensions such as [Block Travel](https://github.com/sashaweiss/vscode_block_travel).
+It is possible to combine this extension with other cursor movement extensions.
 
 You can use the `inRegionMode` context flag in the `when` clause of your keybind to provide different behaviour for region mode vs. cursor mode. The default keybinds are laid out as follows:
 
@@ -41,33 +41,6 @@ You can use the `inRegionMode` context flag in the `when` clause of your keybind
 {
     "key": "DESIRED KEY",
     "command": "CURSOR MOVE & SELECT COMMAND",
-    "when": "editorTextFocus && inRegionMode"
-}
-```
-
-### Block Travel
-
-Add the following to your `keybinds.json`:
-
-```json
-{
-    "key": "ctrl+up",
-    "command": "block-travel.jumpUp",
-    "when": "editorTextFocus && !inRegionMode"
-},
-{
-    "key": "ctrl+down",
-    "command": "block-travel.jumpDown",
-    "when": "editorTextFocus && !inRegionMode"
-},
-{
-    "key": "ctrl+up",
-    "command": "block-travel.selectUp",
-    "when": "editorTextFocus && inRegionMode"
-},    
-{
-    "key": "ctrl+down",
-    "command": "block-travel.selectDown",
     "when": "editorTextFocus && inRegionMode"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,73 @@
 # README
-This is extension for Visual Studio Code to provide function of region selection like Emacs.
+This is an extension for Visual Studio Code which provides region selection similar to that of Emacs.
 
-## Keybindgs
+## Keybindings
 |key|explanation|
 |---|-----------|
-|ctrl+f|move selection cursor to right|
-|ctrl+b|move selection cursor to left|
-|ctrl+p|move selection cursor to up|
-|ctrl+n|move selection cursor to down|
+|ctrl+f|move selection cursor right|
+|ctrl+b|move selection cursor left|
+|ctrl+p|move selection cursor up|
+|ctrl+n|move selection cursor down|
+|right|move selection cursor right|
+|left|move selection cursor left|
+|up|move selection cursor up|
+|down|move selection cursor down|
+|ctrl+right|move selection cursor one word to the right|
+|ctrl+left|move selection cursor one word to the left|
+|ctrl+v|move selection cursor one page down|
+|alt+v|move selection cursor one page up|
+|ctrl+a|move selection cursor to start of line|
+|ctrl+e|move selection cursor to end of line|
+|alt+shift+,|move selection cursor to start of file|
+|alt+shift+.|move selection cursor to end of file|
+|ctrl+y|paste and stop selection|
+|ctrl+w|cut and stop selection|
+|alt+w|copy and stop selection|
 |ctrl+space|start region mode|
 |ctrl+g|exit region mode|
+
+## Compatibility With Other Extensions
+
+It is possible to combine this extension with other selection extensions such as [Block Travel](https://github.com/sashaweiss/vscode_block_travel).
+
+You can use the `inRegionMode` context flag in the `when` clause of your keybind to provide different behaviour for region mode vs. cursor mode. The default keybinds are laid out as follows:
+
+```json
+{
+    "key": <DESIRED KEY>,
+    "command": <CURSOR MOVE COMMAND>,
+    "when": "editorTextFocus && !inRegionMode"
+},
+{
+    "key": <DESIRED KEY>,
+    "command": <CURSOR MOVE & SELECT COMMAND>,
+    "when": "editorTextFocus && inRegionMode"
+}
+```
+
+### Block Travel
+
+Add the following to your `keybinds.json`:
+
+```json
+{
+    "key": "ctrl+up",
+    "command": "block-travel.jumpUp",
+    "when": "editorTextFocus && !inRegionMode"
+},
+{
+    "key": "ctrl+down",
+    "command": "block-travel.jumpDown",
+    "when": "editorTextFocus && !inRegionMode"
+},
+{
+    "key": "ctrl+up",
+    "command": "block-travel.selectUp",
+    "when": "editorTextFocus && inRegionMode"
+},    
+{
+    "key": "ctrl+down",
+    "command": "block-travel.selectDown",
+    "when": "editorTextFocus && inRegionMode"
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# README
+# vscode-emacs-region
 This is an extension for Visual Studio Code which provides region selection similar to that of Emacs.
 
 ## Keybindings
@@ -34,13 +34,13 @@ You can use the `inRegionMode` context flag in the `when` clause of your keybind
 
 ```json
 {
-    "key": <DESIRED KEY>,
-    "command": <CURSOR MOVE COMMAND>,
+    "key": "DESIRED KEY",
+    "command": "CURSOR MOVE COMMAND",
     "when": "editorTextFocus && !inRegionMode"
 },
 {
-    "key": <DESIRED KEY>,
-    "command": <CURSOR MOVE & SELECT COMMAND>,
+    "key": "DESIRED KEY",
+    "command": "CURSOR MOVE & SELECT COMMAND",
     "when": "editorTextFocus && inRegionMode"
 }
 ```
@@ -70,4 +70,4 @@ Add the following to your `keybinds.json`:
     "command": "block-travel.selectDown",
     "when": "editorTextFocus && inRegionMode"
 }
-```
+```

--- a/package.json
+++ b/package.json
@@ -21,34 +21,191 @@
     "contributes": {
         "keybindings": [
             {
-                "key": "ctrl+F",
-                "command": "emacs.cursorRight",
-                "when": "editorTextFocus"
+                "key": "ctrl+f",
+                "command": "cursorRight",
+                "when": "editorTextFocus && !inRegionMode"
             },
                         {
-                "key": "ctrl+B",
-                "command": "emacs.cursorLeft",
-                "when": "editorTextFocus"
+                "key": "ctrl+b",
+                "command": "cursorLeft",
+                "when": "editorTextFocus && !inRegionMode"
             },
             {
-                "key": "ctrl+P",
-                "command": "emacs.cursorUp",
-                "when": "editorTextFocus"
+                "key": "ctrl+p",
+                "command": "cursorUp",
+                "when": "editorTextFocus && !inRegionMode"
             },
             {
-                "key": "ctrl+N",
-                "command": "emacs.cursorDown",
-                "when": "editorTextFocus"
+                "key": "ctrl+n",
+                "command": "cursorDown",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "ctrl+f",
+                "command": "cursorRightSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "ctrl+b",
+                "command": "cursorLeftSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "ctrl+p",
+                "command": "cursorUpSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "ctrl+n",
+                "command": "cursorDownSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "left",
+                "command": "cursorLeft",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "ctrl+left",
+                "command": "cursorWordStartLeft",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "down",
+                "command": "cursorDown",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "right",
+                "command": "cursorRight",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "ctrl+right",
+                "command": "cursorWordEndRight",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "up",
+                "command": "cursorUp",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "ctrl+a",
+                "command": "cursorHome",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "ctrl+e",
+                "command": "cursorEnd",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "ctrl+v",
+                "command": "cursorPageDown",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "alt+v",
+                "command": "cursorPageUp",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "alt+shift+,",
+                "command": "cursorTop",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "alt+shift+.",
+                "command": "cursorBottom",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "left",
+                "command": "cursorLeftSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "ctrl+left",
+                "command": "cursorWordStartLeftSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "down",
+                "command": "cursorDownSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "right",
+                "command": "cursorRightSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "ctrl+right",
+                "command": "cursorWordEndRightSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "up",
+                "command": "cursorUpSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "ctrl+a",
+                "command": "cursorHomeSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "ctrl+e",
+                "command": "cursorEndSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "ctrl+v",
+                "command": "cursorPageDownSelect",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "alt+v",
+                "command": "cursorPageUpSelect",
+                "when": "editorTextFocus && !inRegionMode"
+            },
+            {
+                "key": "alt+shift+,",
+                "command": "cursorTopSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "alt+shift+.",
+                "command": "cursorBottomSelect",
+                "when": "editorTextFocus && inRegionMode"
+            },
+            {
+                "key": "alt+w",
+                "command": "emacs.action.clipboardCopyAction"
+            },
+            {
+                "key": "ctrl+w",
+                "command": "emacs.action.clipboardCutAction"
+            },
+            {
+                "key": "ctrl+y",
+                "command": "emacs.action.clipboardPasteAction"
+            },
+            {
+                "key": "ctrl+g",
+                "command": "cancelSelection",
+                "when": "editorHasTextFocus && editorHasSelection"
+            },
+            {
+                "key": "ctrl+g",
+                "command": "emacs.exitRegionMode",
+                "when": "inRegionMode"
             },
             {
                 "key": "ctrl+space",
                 "command": "emacs.startRegionMode",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+G",
-                "command": "emacs.exitRegionMode",
-                "when": "editorTextFocus"
+                "when": "editorFocus"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,13 +13,11 @@ var inRegionMode: boolean = false;
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
-    // リージョン選択モードを開始
     context.subscriptions.push(vscode.commands.registerCommand('emacs.startRegionMode', ()=>{
         removeSelection();
         inRegionMode = true;
     }));
 
-    // リージョン選択モードを終了
     context.subscriptions.push(vscode.commands.registerCommand('emacs.exitRegionMode', ()=>{
         if(!inRegionMode){
             return ;
@@ -30,7 +28,6 @@ export function activate(context: vscode.ExtensionContext) {
 
     var cursorMoves : string[] = ["cursorUp", "cursorDown", "cursorLeft", "cursorRight"];
 
-    // リージョン選択モードなら、選択コマンドを実行
     cursorMoves.forEach((cursormove) => {
         context.subscriptions.push(vscode.commands.registerCommand("emacs."+cursormove, ()=>{
             vscode.commands.executeCommand(inRegionMode? cursormove+"Select" : cursormove);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,32 +7,37 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-var inRegionMode: boolean = false;
-
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
+    setRegionMode(false);
 
     context.subscriptions.push(vscode.commands.registerCommand('emacs.startRegionMode', ()=>{
-        removeSelection();
-        inRegionMode = true;
+        startRegionMode();
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand('emacs.exitRegionMode', ()=>{
-        if(!inRegionMode){
-            return ;
-        }
-        removeSelection();
-        inRegionMode = false;
+        exitRegionMode()
     }));
 
-    var cursorMoves : string[] = ["cursorUp", "cursorDown", "cursorLeft", "cursorRight"];
+    var selectionActions: string[] = ["action.clipboardCopyAction", "action.clipboardPasteAction", "action.clipboardCutAction"]
+    selectionActions.forEach((selectionAction) => {
+        context.subscriptions.push(vscode.commands.registerCommand("emacs." + selectionAction, () => {
+            vscode.commands.executeCommand("editor." + selectionAction).then(exitRegionMode);
+        }))
+    })
+}
 
-    cursorMoves.forEach((cursormove) => {
-        context.subscriptions.push(vscode.commands.registerCommand("emacs."+cursormove, ()=>{
-            vscode.commands.executeCommand(inRegionMode? cursormove+"Select" : cursormove);
-        }));
-    });
+function startRegionMode() {
+    setRegionMode(true).then(removeSelection);
+}
+
+function exitRegionMode() {
+    setRegionMode(false).then(removeSelection);
+}
+
+function setRegionMode(value): Thenable<{}> {
+    return vscode.commands.executeCommand('setContext', 'inRegionMode', value);
 }
 
 function removeSelection(){
@@ -42,4 +47,5 @@ function removeSelection(){
 
 // this method is called when your extension is deactivated
 export function deactivate() {
+    setRegionMode(false)
 }


### PR DESCRIPTION
Added more commands (next word, page down, start of document etc.) to
allow for faster navigation.

Also improved compatibility with other extensions such as Block Travel
by allowing the user to bind cursor movement with the `inRegionMode`
context flag (example in README.md).

Improved cut/copy/paste functionality by ensuring that the operation
is complete before removing the selection. This prevents cut from
accidentally cutting the wrong text / less text than intended.

See the commit log for detailed changes.